### PR TITLE
Inline picker view

### DIFF
--- a/AppDelegate.swift
+++ b/AppDelegate.swift
@@ -36,7 +36,7 @@ public final class AppDelegate: NSObject, UIApplicationDelegate {
 
 	private static let persistentStoreCoordinator: NSPersistentStoreCoordinator = {
 		var error: NSError?
-		let storeURL = NSURL(fileURLWithPath:applicationDocumentsDirectory.stringByAppendingPathComponent("Kraftstoffrechner.sqlite"))!
+		let storeURL = NSURL(fileURLWithPath:applicationDocumentsDirectory)!.URLByAppendingPathComponent("Kraftstoffrechner.sqlite")
 		let options = [NSMigratePersistentStoresAutomaticallyOption: true, NSInferMappingModelAutomaticallyOption: true]
 
 		let persistentStoreCoordinator = NSPersistentStoreCoordinator(managedObjectModel:managedObjectModel)

--- a/AppDelegate.swift
+++ b/AppDelegate.swift
@@ -584,7 +584,7 @@ public final class AppDelegate: NSObject, UIApplicationDelegate {
 		// - when sum of all events equals the odometer value
 		// - when forced to do so
 		if !forceOdometerUpdate {
-			if car.odometer.compare(car.distanceTotalSum) != .OrderedDescending {
+			if car.odometer <= car.distanceTotalSum {
 				forceOdometerUpdate = true
 			}
 		}
@@ -628,10 +628,7 @@ public final class AppDelegate: NSObject, UIApplicationDelegate {
 				let inheritedDistance   = event.inheritedDistance
 				let inheritedFuelVolume = event.inheritedFuelVolume
 
-				if inheritedCost.compare(zero) == .OrderedDescending ||
-				   inheritedDistance.compare(zero) == .OrderedDescending ||
-				   inheritedFuelVolume.compare(zero) == .OrderedDescending {
-
+				if inheritedCost > zero || inheritedDistance > zero || inheritedFuelVolume > zero {
 					while row > 0 {
 						let youngerEvent = youngerEvents[--row]
 
@@ -669,7 +666,7 @@ public final class AppDelegate: NSObject, UIApplicationDelegate {
 		// - when sum of all events equals the odometer value
 		// - when forced to do so
 		if !forceOdometerUpdate {
-			if car.odometer.compare(car.distanceTotalSum) != .OrderedDescending {
+			if car.odometer <= car.distanceTotalSum {
 				forceOdometerUpdate = true
 			}
 		}

--- a/Classes/CSVImporter.swift
+++ b/Classes/CSVImporter.swift
@@ -194,7 +194,7 @@ public class CSVImporter {
 	private func guessDistanceForParsedDistance(distance: NSDecimalNumber, andFuelVolume liters: NSDecimalNumber) -> NSDecimalNumber {
 		let convDistance = distance << 3
 
-		if NSDecimalNumber.zero().compare(liters) != .OrderedAscending {
+		if liters <= NSDecimalNumber.zero() {
 			return distance
 		}
 
@@ -217,12 +217,12 @@ public class CSVImporter {
 		let hiBound = NSDecimalNumber(integer: 20)
     
 		// conversion only when unconverted >= lowerBound
-		if rawConsumption.compare(hiBound) == .OrderedAscending {
+		if rawConsumption < hiBound {
 			return distance
 		}
 
 		// conversion only when lowerBound <= convConversion <= highBound
-		if convConsumption.compare(loBound) == .OrderedAscending || convConsumption.compare(hiBound) == .OrderedDescending {
+		if convConsumption < loBound || convConsumption > hiBound {
 			return distance
 		}
 

--- a/Classes/CarConfigurationController.swift
+++ b/Classes/CarConfigurationController.swift
@@ -313,7 +313,7 @@ class CarConfigurationController: PageViewController, UIViewControllerRestoratio
 		if !self.editingExistingObject
 			&& self.name == ""
 			&& self.plate == ""
-			&& self.odometer!.compare(NSDecimalNumber.zero()) == .OrderedSame {
+			&& self.odometer! == NSDecimalNumber.zero() {
 			showCancelSheet = false
 		}
 

--- a/Classes/CarConfigurationController.swift
+++ b/Classes/CarConfigurationController.swift
@@ -266,7 +266,7 @@ class CarConfigurationController: PageViewController, UIViewControllerRestoratio
 
 	//MARK: - Programmatically Selecting Table Rows
 
-	func activateTextFieldAtIndexPath(indexPath: NSIndexPath) {
+	private func textFieldAtIndexPath(indexPath: NSIndexPath) -> UITextField? {
 		let cell = tableView.cellForRowAtIndexPath(indexPath)!
 		let field: UITextField?
 
@@ -280,9 +280,15 @@ class CarConfigurationController: PageViewController, UIViewControllerRestoratio
 			field = nil
 		}
 
-		if let field = field {
+		return field
+	}
+
+	private func activateTextFieldAtIndexPath(indexPath: NSIndexPath) {
+		if let field = textFieldAtIndexPath(indexPath) {
 			field.userInteractionEnabled = true
 			field.becomeFirstResponder()
+			tableView.beginUpdates()
+			tableView.endUpdates()
 		}
 	}
 
@@ -413,8 +419,15 @@ class CarConfigurationController: PageViewController, UIViewControllerRestoratio
 
 	func tableView(tableView: UITableView, didSelectRowAtIndexPath indexPath: NSIndexPath) {
 		activateTextFieldAtIndexPath(indexPath)
-
 		tableView.scrollToRowAtIndexPath(indexPath, atScrollPosition:.Middle, animated:true)
+	}
+
+	func tableView(tableView: UITableView, didDeselectRowAtIndexPath indexPath: NSIndexPath) {
+		if let field = textFieldAtIndexPath(indexPath) {
+			field.resignFirstResponder()
+			tableView.beginUpdates()
+			tableView.endUpdates()
+		}
 	}
 
 	//MARK: - Memory Management

--- a/Classes/CarTableCell.swift
+++ b/Classes/CarTableCell.swift
@@ -20,17 +20,8 @@ class CarTableCell: EditableProxyPageCell, UIPickerViewDataSource, UIPickerViewD
 	private let maximumDescriptionLength = 24
 
 	// Attributes for custom PickerViews
-	private let prefixAttributesDict : [NSObject:AnyObject] = {
-		let font = UIFont(name: "HelveticaNeue", size: 24)!
-		return [NSFontAttributeName : font,
-				NSForegroundColorAttributeName : UIColor.blackColor()]
-	}()
-
-	private let suffixAttributesDict : [NSObject:AnyObject] = {
-		let font = UIFont(name: "HelveticaNeue", size: 18)!
-		return [NSFontAttributeName : font,
-				NSForegroundColorAttributeName : UIColor.darkGrayColor()]
-	}()
+	private var prefixAttributes = [NSObject:AnyObject]()
+	private var suffixAttributes = [NSObject:AnyObject]()
 
 	required init() {
 		self.carPicker = UIPickerView()
@@ -46,6 +37,17 @@ class CarTableCell: EditableProxyPageCell, UIPickerViewDataSource, UIPickerViewD
 
 	required init(coder aDecoder: NSCoder) {
 	    fatalError("init(coder:) has not been implemented")
+	}
+
+	override func setupFonts() {
+		super.setupFonts()
+
+		prefixAttributes = [NSFontAttributeName : UIFont.applicationFontForStyle(UIFontTextStyleSubheadline),
+			NSForegroundColorAttributeName : UIColor.blackColor()]
+		suffixAttributes = [NSFontAttributeName : UIFont.applicationFontForStyle(UIFontTextStyleCaption2),
+			NSForegroundColorAttributeName : UIColor.darkGrayColor()]
+
+		self.carPicker.reloadAllComponents()
 	}
 
 	override func prepareForReuse() {
@@ -123,9 +125,9 @@ class CarTableCell: EditableProxyPageCell, UIPickerViewDataSource, UIPickerViewD
 			label.lineBreakMode = .ByTruncatingTail
 		}
 
-		let attributedText = NSMutableAttributedString(string: "\(name)  \(info)", attributes: suffixAttributesDict)
+		let attributedText = NSMutableAttributedString(string: "\(name)  \(info)", attributes: suffixAttributes)
 		attributedText.beginEditing()
-		attributedText.setAttributes(prefixAttributesDict, range:NSRange(location:0, length:count(name)))
+		attributedText.setAttributes(prefixAttributes, range:NSRange(location:0, length:count(name)))
 		attributedText.endEditing()
 		label.attributedText = attributedText
 

--- a/Classes/CarTableCell.swift
+++ b/Classes/CarTableCell.swift
@@ -10,8 +10,9 @@ import UIKit
 
 class CarTableCell: EditableProxyPageCell, UIPickerViewDataSource, UIPickerViewDelegate {
 
-	var carPicker: UIPickerView
+	private var carPicker: UIPickerView
 	var cars: [Car]!
+	private var carPickerConstraints = [NSLayoutConstraint]()
 
 	// Standard cell geometry
 	private let PickerViewCellWidth: CGFloat        = 290.0
@@ -24,15 +25,21 @@ class CarTableCell: EditableProxyPageCell, UIPickerViewDataSource, UIPickerViewD
 	private var suffixAttributes = [NSObject:AnyObject]()
 
 	required init() {
-		self.carPicker = UIPickerView()
+		carPicker = UIPickerView()
 
 		super.init()
 
-		self.carPicker.showsSelectionIndicator = true
-		self.carPicker.dataSource              = self
-		self.carPicker.delegate                = self
+		let carPickerHeightConstraint = NSLayoutConstraint(item: carPicker, attribute: .Height, relatedBy: .Equal, toItem: nil, attribute: .NotAnAttribute, multiplier: 1.0, constant: 162.0)
+		carPickerHeightConstraint.priority = 750
+		carPicker.showsSelectionIndicator = true
+		carPicker.dataSource              = self
+		carPicker.delegate                = self
+		carPicker.setTranslatesAutoresizingMaskIntoConstraints(false)
+		carPicker.hidden = true
+		carPicker.addConstraint(carPickerHeightConstraint)
+		contentView.addSubview(carPicker)
 
-		self.textField.inputView = self.carPicker
+		carPickerConstraints = NSLayoutConstraint.constraintsWithVisualFormat("V:[keyLabel]-[carPicker]-|", options: .allZeros, metrics: nil, views: ["keyLabel" : keyLabel, "carPicker" : carPicker]) as! [NSLayoutConstraint]
 	}
 
 	required init(coder aDecoder: NSCoder) {
@@ -89,6 +96,16 @@ class CarTableCell: EditableProxyPageCell, UIPickerViewDataSource, UIPickerViewD
 		self.delegate.valueChanged(car, identifier:self.valueIdentifier)
 	}
 
+	private func showPicker(show: Bool) {
+		if show {
+			contentView.addConstraints(carPickerConstraints)
+			carPicker.hidden = false
+		} else {
+			contentView.removeConstraints(carPickerConstraints)
+			carPicker.hidden = true
+		}
+	}
+
 	//MARK: - UIPickerViewDataSource
 
 	func numberOfComponentsInPickerView(pickerView: UIPickerView) -> Int {
@@ -136,5 +153,15 @@ class CarTableCell: EditableProxyPageCell, UIPickerViewDataSource, UIPickerViewD
 		label.accessibilityLabel = "\(name) \(info)"
 
 		return label
+	}
+
+	//MARK: - UITextFieldDelegate
+
+	func textFieldDidBeginEditing(textField: UITextField) {
+		showPicker(true)
+	}
+
+	override func textFieldDidEndEditing(textField: UITextField) {
+		showPicker(false)
 	}
 }

--- a/Classes/CarTableCell.swift
+++ b/Classes/CarTableCell.swift
@@ -57,7 +57,7 @@ class CarTableCell: EditableProxyPageCell, UIPickerViewDataSource, UIPickerViewD
 		self.carPicker.reloadAllComponents()
 	}
 
-	override func configureForData(object: AnyObject!, viewController: AnyObject!, tableView: UITableView!, indexPath: NSIndexPath) {
+	override func configureForData(object: AnyObject?, viewController: UIViewController, tableView: UITableView, indexPath: NSIndexPath) {
 		super.configureForData(object, viewController:viewController, tableView:tableView, indexPath:indexPath)
 
 		let dictionary = object as! [NSObject:AnyObject]

--- a/Classes/CarViewController.swift
+++ b/Classes/CarViewController.swift
@@ -456,7 +456,7 @@ class CarViewController: UITableViewController, UIDataSourceModelAssociation, UI
 		let distance   = managedObject.distanceTotalSum
 		let fuelVolume = managedObject.fuelVolumeTotalSum
 
-		if distance.compare(NSDecimalNumber.zero()) == .OrderedDescending && fuelVolume.compare(NSDecimalNumber.zero()) == .OrderedDescending {
+		if distance > NSDecimalNumber.zero() && fuelVolume > NSDecimalNumber.zero() {
 			avgConsumption = Formatters.sharedFuelVolumeFormatter.stringFromNumber(Units.consumptionForKilometers(distance, liters:fuelVolume, inUnit:consumptionUnit))!
 			tableCell.topRightAccessibilityLabel = avgConsumption
 			tableCell.botRightAccessibilityLabel = Units.consumptionUnitAccessibilityDescription(consumptionUnit)

--- a/Classes/CarViewController.swift
+++ b/Classes/CarViewController.swift
@@ -177,9 +177,9 @@ class CarViewController: UITableViewController, UIDataSourceModelAssociation, UI
 				helpView.image = UIImage(named:helpImageName)
 				helpView.frame = helpViewFrame
 			} else {
-				let helpImage  = UIImage(named:NSLocalizedString(helpImageName, comment:""))!.imageWithRenderingMode(.AlwaysTemplate)
+				let helpImage   = UIImage(named:NSLocalizedString(helpImageName, comment:""))!.imageWithRenderingMode(.AlwaysTemplate)
 
-				helpView       = UIImageView(image:helpImage)
+				helpView        = UIImageView(image:helpImage)
 				helpView!.tag   = 100
 				helpView!.frame = helpViewFrame
 				helpView!.alpha = animated ? 0.0 : 1.0

--- a/Classes/ConsumptionTableCell.swift
+++ b/Classes/ConsumptionTableCell.swift
@@ -53,7 +53,7 @@ class ConsumptionTableCell: PageCell {
 		self.coloredLabel.minimumScaleFactor = 12.0/self.coloredLabel.font.pointSize
 	}
 
-	override func configureForData(object: AnyObject!, viewController: AnyObject!, tableView: UITableView!, indexPath: NSIndexPath) {
+	override func configureForData(object: AnyObject?, viewController: UIViewController, tableView: UITableView, indexPath: NSIndexPath) {
 		super.configureForData(object, viewController:viewController, tableView:tableView, indexPath:indexPath)
 
 		let dictionary = object as! [NSObject:AnyObject]

--- a/Classes/DateEditTableCell.swift
+++ b/Classes/DateEditTableCell.swift
@@ -10,12 +10,25 @@ import UIKit
 
 class DateEditTableCell: EditableProxyPageCell {
 
-	var valueTimestamp: String?
-	var dateFormatter: NSDateFormatter!
-	var autoRefreshedDate = false
+	private var valueTimestamp: String?
+	private var dateFormatter: NSDateFormatter!
+	private var autoRefreshedDate = false
+	private var datePicker: UIDatePicker
+	private var datePickerConstraints = [NSLayoutConstraint]()
 
 	required init() {
+		datePicker = UIDatePicker()
+
 		super.init()
+
+		datePicker.datePickerMode = .DateAndTime
+		datePicker.addTarget(self, action:"datePickerValueChanged:", forControlEvents:.ValueChanged)
+		datePicker.setTranslatesAutoresizingMaskIntoConstraints(false)
+		datePicker.hidden = true
+
+		contentView.addSubview(datePicker)
+
+		datePickerConstraints = NSLayoutConstraint.constraintsWithVisualFormat("V:[keyLabel]-[datePicker]-|", options: .allZeros, metrics: nil, views: ["keyLabel" : keyLabel, "datePicker" : datePicker]) as! [NSLayoutConstraint]
 
 		NSNotificationCenter.defaultCenter().addObserver(self,
 												selector:"significantTimeChange:",
@@ -37,9 +50,9 @@ class DateEditTableCell: EditableProxyPageCell {
 
 		let dictionary = object as! [NSObject:AnyObject]
 
-		self.valueTimestamp      = dictionary["valueTimestamp"] as? String
-		self.dateFormatter       = dictionary["formatter"] as! NSDateFormatter
-		self.autoRefreshedDate   = dictionary["autorefresh"]?.boolValue ?? false
+		self.valueTimestamp    = dictionary["valueTimestamp"] as? String
+		self.dateFormatter     = dictionary["formatter"] as! NSDateFormatter
+		self.autoRefreshedDate = dictionary["autorefresh"]?.boolValue ?? false
 
 		let value = self.delegate.valueForIdentifier(self.valueIdentifier) as? NSDate
 		self.textFieldProxy.text = value.flatMap { self.dateFormatter.stringFromDate($0) } ?? ""
@@ -55,7 +68,7 @@ class DateEditTableCell: EditableProxyPageCell {
 			self.delegate.valueChanged(NSDate.distantPast(), identifier:timestamp)
 		}
 
-		refreshDatePickerInputViewWithDate(nil, forceRecreation:true)
+		refreshDatePickerWithDate(nil)
 	}
 
 	func datePickerValueChanged(sender: UIDatePicker) {
@@ -71,35 +84,27 @@ class DateEditTableCell: EditableProxyPageCell {
 		}
 	}
 
-	private func refreshDatePickerInputViewWithDate(date: NSDate?, forceRecreation: Bool) {
+	private func refreshDatePickerWithDate(date: NSDate?) {
 		let now = NSDate()
-
-		// Get previous input view
-		var datePicker: UIDatePicker?
-
-		if !forceRecreation {
-			datePicker = self.textField.inputView as? UIDatePicker
-		}
 
 		// If not specified get the date to be selected from the delegate
 		let effectiveDate = (date ?? self.delegate.valueForIdentifier(self.valueIdentifier) as? NSDate) ?? now
 
-		// Create new datepicker with a correct 'today' flag
-		if datePicker == nil {
-			datePicker = UIDatePicker()
-			datePicker!.datePickerMode = .DateAndTime
-
-			datePicker!.addTarget(self, action:"datePickerValueChanged:", forControlEvents:.ValueChanged)
-
-			self.textField.inputView = datePicker
-		}
-
-		datePicker!.maximumDate = NSDate.dateWithoutSeconds(now)
-		datePicker!.setDate(NSDate.dateWithoutSeconds(effectiveDate), animated:false)
+		datePicker.maximumDate = NSDate.dateWithoutSeconds(now)
+		datePicker.setDate(NSDate.dateWithoutSeconds(effectiveDate), animated:false)
 
 		// Immediate update when we are the first responder and notify delegate about new value too
-		datePickerValueChanged(datePicker!)
-		self.textField.reloadInputViews()
+		datePickerValueChanged(datePicker)
+	}
+
+	private func showDatePicker(show: Bool) {
+		if show {
+			contentView.addConstraints(datePickerConstraints)
+			datePicker.hidden = false
+		} else {
+			contentView.removeConstraints(datePickerConstraints)
+			datePicker.hidden = true
+		}
 	}
 
 	//MARK: - UITextFieldDelegate
@@ -121,6 +126,12 @@ class DateEditTableCell: EditableProxyPageCell {
 		}
 
 		// Update the date picker with the selected time
-		refreshDatePickerInputViewWithDate(selectedDate, forceRecreation:false)
+		refreshDatePickerWithDate(selectedDate)
+
+		showDatePicker(true)
+	}
+
+	override func textFieldDidEndEditing(textField: UITextField) {
+		showDatePicker(false)
 	}
 }

--- a/Classes/DateEditTableCell.swift
+++ b/Classes/DateEditTableCell.swift
@@ -32,7 +32,7 @@ class DateEditTableCell: EditableProxyPageCell {
 		self.textFieldProxy.textColor = valid ? UIColor.blackColor() : invalidTextColor
 	}
 
-	override func configureForData(object: AnyObject!, viewController: AnyObject!, tableView: UITableView!, indexPath: NSIndexPath) {
+	override func configureForData(object: AnyObject?, viewController: UIViewController, tableView: UITableView, indexPath: NSIndexPath) {
 		super.configureForData(object, viewController:viewController, tableView:tableView, indexPath:indexPath)
 
 		let dictionary = object as! [NSObject:AnyObject]

--- a/Classes/EditablePageCell.swift
+++ b/Classes/EditablePageCell.swift
@@ -53,8 +53,11 @@ class EditablePageCell: PageCell, UITextFieldDelegate {
 
 		self.contentView.addSubview(keyLabel)
 
+		let keyLabelBottomConstraint = NSLayoutConstraint(item: keyLabel, attribute: .Bottom, relatedBy: .Equal, toItem: contentView, attribute: .BottomMargin, multiplier: 1.0, constant: 0.0)
+		keyLabelBottomConstraint.priority = 500
 		self.contentView.addConstraints(NSLayoutConstraint.constraintsWithVisualFormat("|-[keyLabel]-[textField]-|", options: .allZeros, metrics: nil, views: ["keyLabel" : keyLabel, "textField" : textField]))
-		self.contentView.addConstraints(NSLayoutConstraint.constraintsWithVisualFormat("V:|-[keyLabel]-|", options: .allZeros, metrics: nil, views: ["keyLabel" : keyLabel]))
+		self.contentView.addConstraint(NSLayoutConstraint(item: keyLabel, attribute: .Top, relatedBy: .Equal, toItem: contentView, attribute: .TopMargin, multiplier: 1.0, constant: 0.0))
+		self.contentView.addConstraint(keyLabelBottomConstraint)
 		self.contentView.addConstraint(NSLayoutConstraint(item: textField, attribute: .Baseline, relatedBy: .Equal, toItem: keyLabel, attribute: .Baseline, multiplier: 1.0, constant: 0.0))
 
 		setupFonts()

--- a/Classes/EditablePageCell.swift
+++ b/Classes/EditablePageCell.swift
@@ -87,7 +87,7 @@ class EditablePageCell: PageCell, UITextFieldDelegate {
 		}
 	}
 
-	override func configureForData(object: AnyObject!, viewController: AnyObject!, tableView: UITableView!, indexPath: NSIndexPath) {
+	override func configureForData(object: AnyObject?, viewController: UIViewController, tableView: UITableView, indexPath: NSIndexPath) {
 		super.configureForData(object, viewController:viewController, tableView:tableView, indexPath:indexPath)
 
 		let dictionary = object as! [NSObject:AnyObject]

--- a/Classes/EditableProxyPageCell.swift
+++ b/Classes/EditableProxyPageCell.swift
@@ -49,7 +49,7 @@ class EditableProxyPageCell: EditablePageCell {
 	override var accessibilityLabel: String! {
 		get {
 			if let text1 = self.keyLabel.text, text2 = self.textFieldProxy.text {
-				return String(format:"%@ %@", text1, text2)
+				return "\(text1) \(text2)"
 			}
 			return nil
 		}

--- a/Classes/FuelCalculatorController.swift
+++ b/Classes/FuelCalculatorController.swift
@@ -304,7 +304,7 @@ class FuelCalculatorController: PageViewController, NSFetchedResultsControllerDe
                   cellClass:NumberEditTableCell.self,
                    cellData:["label": Units.fuelUnitDescription(fuelUnit, discernGallons:false, pluralization:true),
                              "suffix": " ".stringByAppendingString(Units.fuelUnitString(fuelUnit)),
-                             "formatter": KSVolumeIsMetric(fuelUnit)
+                             "formatter": fuelUnit.isMetric
                                                 ? Formatters.sharedFuelVolumeFormatter
                                                 : Formatters.sharedPreciseFuelVolumeFormatter,
                              "valueIdentifier": "fuelVolume"],
@@ -411,7 +411,7 @@ class FuelCalculatorController: PageViewController, NSFetchedResultsControllerDe
 		// Update the tableview
 		let odoChanged = oldCar == nil || oldCar!.odometerUnit != self.car!.odometerUnit
 
-		let fuelChanged = oldCar == nil || KSVolumeIsMetric(oldCar!.ksFuelUnit) != KSVolumeIsMetric(self.car!.ksFuelUnit)
+		let fuelChanged = oldCar == nil || oldCar!.ksFuelUnit.isMetric != self.car!.ksFuelUnit.isMetric
 
 		var count = 0
 

--- a/Classes/FuelCalculatorController.swift
+++ b/Classes/FuelCalculatorController.swift
@@ -166,7 +166,7 @@ class FuelCalculatorController: PageViewController, NSFetchedResultsControllerDe
 
 		let zero = NSDecimalNumber.zero()
 
-		if (distance == nil || distance!.compare(zero) == .OrderedSame) && (fuelVolume == nil || fuelVolume!.compare(zero) == .OrderedSame) && (price == nil || price!.compare(zero) == .OrderedSame) {
+		if (distance == nil || distance! == zero) && (fuelVolume == nil || fuelVolume! == zero) && (price == nil || price! == zero) {
 			return
 		}
 
@@ -199,7 +199,7 @@ class FuelCalculatorController: PageViewController, NSFetchedResultsControllerDe
 
 		let zero = NSDecimalNumber.zero()
 
-		if (distance != nil && distance!.compare(zero) != .OrderedDescending) || (fuelVolume != nil && fuelVolume!.compare(zero) != .OrderedDescending) {
+		if (distance == nil || distance! <= zero) || (fuelVolume == nil || fuelVolume! <= zero) {
 			return false
 		}
 
@@ -557,7 +557,7 @@ class FuelCalculatorController: PageViewController, NSFetchedResultsControllerDe
 
 		if self.car == nil {
 			saveValid = false
-		} else if (distance == nil || distance!.compare(NSDecimalNumber.zero()) == .OrderedSame) || (fuelVolume == nil || fuelVolume!.compare(NSDecimalNumber.zero()) == .OrderedSame) {
+		} else if (distance == nil || distance! == NSDecimalNumber.zero()) || (fuelVolume == nil || fuelVolume! == NSDecimalNumber.zero()) {
 			saveValid = false
 		} else if date == nil || AppDelegate.managedObjectContext(self.managedObjectContext, containsEventWithCar:self.car!, andDate:self.date!) {
 			saveValid = false
@@ -581,14 +581,14 @@ class FuelCalculatorController: PageViewController, NSFetchedResultsControllerDe
 		let rawDistance  = Units.kilometersForDistance(self.distance!, withUnit:odometerUnit)
 		let convDistance = rawDistance - self.car!.odometer
     
-		if NSDecimalNumber.zero().compare(convDistance) != .OrderedAscending {
+		if convDistance <= NSDecimalNumber.zero() {
 			return false
 		}
     
 		// 2.) consumption with converted distances is more 'logical'
 		let liters = Units.litersForVolume(fuelVolume!, withUnit:self.car!.ksFuelUnit)
     
-		if NSDecimalNumber.zero().compare(liters) != .OrderedAscending {
+		if liters <= NSDecimalNumber.zero() {
 			return false
 		}
 
@@ -624,12 +624,12 @@ class FuelCalculatorController: PageViewController, NSFetchedResultsControllerDe
 		}
     
 		// conversion only when rawConsumtion <= lowerBound
-		if rawConsumption.compare(loBound) == .OrderedDescending {
+		if rawConsumption > loBound {
 			return false
 		}
 
 		// conversion only when lowerBound <= convConversion <= highBound
-		if convConsumption.compare(loBound) == .OrderedAscending || convConsumption.compare(hiBound) == .OrderedDescending {
+		if convConsumption < loBound || convConsumption > hiBound {
 			return false
 		}
     
@@ -795,7 +795,7 @@ class FuelCalculatorController: PageViewController, NSFetchedResultsControllerDe
 		// DecimalNumbers <= 0.0 are invalid
 		if let decimalNumber = newValue as? NSDecimalNumber {
 			if valueIdentifier != "price" {
-				if decimalNumber.compare(NSDecimalNumber.zero()) != .OrderedDescending {
+				if decimalNumber <= NSDecimalNumber.zero() {
 					return false
 				}
 			}

--- a/Classes/FuelCalculatorController.swift
+++ b/Classes/FuelCalculatorController.swift
@@ -488,9 +488,9 @@ class FuelCalculatorController: PageViewController, NSFetchedResultsControllerDe
 		}
 	}
 
-	//MARK: - Programatically Selecting Table Rows
+	//MARK: - Programmatically Selecting Table Rows
 
-	func activateTextFieldAtIndexPath(indexPath: NSIndexPath) {
+	private func textFieldAtIndexPath(indexPath: NSIndexPath) -> UITextField? {
 		let cell = self.tableView.cellForRowAtIndexPath(indexPath)!
 		let field : UITextField?
 
@@ -503,10 +503,15 @@ class FuelCalculatorController: PageViewController, NSFetchedResultsControllerDe
 		} else {
 			field = nil
 		}
+		return field
+	}
 
-		if let field = field {
+	private func activateTextFieldAtIndexPath(indexPath: NSIndexPath) {
+		if let field = textFieldAtIndexPath(indexPath) {
 			field.userInteractionEnabled = true
 			field.becomeFirstResponder()
+			tableView.beginUpdates()
+			tableView.endUpdates()
 		}
 	}
 
@@ -835,6 +840,14 @@ class FuelCalculatorController: PageViewController, NSFetchedResultsControllerDe
 	func tableView(tableView: UITableView, didSelectRowAtIndexPath indexPath: NSIndexPath) {
 		activateTextFieldAtIndexPath(indexPath)
 		tableView.scrollToRowAtIndexPath(indexPath, atScrollPosition:.Middle, animated:true)
+	}
+
+	func tableView(tableView: UITableView, didDeselectRowAtIndexPath indexPath: NSIndexPath) {
+		if let field = textFieldAtIndexPath(indexPath) {
+			field.resignFirstResponder()
+			tableView.beginUpdates()
+			tableView.endUpdates()
+		}
 	}
 
 	//MARK: -

--- a/Classes/FuelEventEditorController.swift
+++ b/Classes/FuelEventEditorController.swift
@@ -393,23 +393,30 @@ class FuelEventEditorController: PageViewController, UIViewControllerRestoration
 		}
 	}
 
-	//MARK: - Programatically Selecting Table Rows
+	//MARK: - Programmatically Selecting Table Rows
 
-	func activateTextFieldAtIndexPath(indexPath: NSIndexPath) {
-		let cell = self.tableView.cellForRowAtIndexPath(indexPath)
-		let field: UITextField?
-    
-		if let dateCell = cell as? DateEditTableCell {
+	private func textFieldAtIndexPath(indexPath: NSIndexPath) -> UITextField? {
+		let cell = self.tableView.cellForRowAtIndexPath(indexPath)!
+		let field : UITextField?
+
+		if let carCell = cell as? CarTableCell {
+			field = carCell.textField
+		} else if let dateCell = cell as? DateEditTableCell {
 			field = dateCell.textField
 		} else if let numberCell = cell as? NumberEditTableCell {
 			field = numberCell.textField
 		} else {
 			field = nil
 		}
+		return field
+	}
 
-		if let field = field {
+	func activateTextFieldAtIndexPath(indexPath: NSIndexPath) {
+		if let field = textFieldAtIndexPath(indexPath) {
 			field.userInteractionEnabled = true
 			field.becomeFirstResponder()
+			tableView.beginUpdates()
+			tableView.endUpdates()
 		}
 	}
 
@@ -530,8 +537,15 @@ class FuelEventEditorController: PageViewController, UIViewControllerRestoration
 
 	func tableView(tableView: UITableView, didSelectRowAtIndexPath indexPath: NSIndexPath) {
 		activateTextFieldAtIndexPath(indexPath)
-
 		tableView.scrollToRowAtIndexPath(indexPath, atScrollPosition:.Middle, animated:true)
+	}
+
+	func tableView(tableView: UITableView, didDeselectRowAtIndexPath indexPath: NSIndexPath) {
+		if let field = textFieldAtIndexPath(indexPath) {
+			field.resignFirstResponder()
+			tableView.beginUpdates()
+			tableView.endUpdates()
+		}
 	}
 
 	//MARK: - Memory Management

--- a/Classes/FuelEventEditorController.swift
+++ b/Classes/FuelEventEditorController.swift
@@ -289,7 +289,7 @@ class FuelEventEditorController: PageViewController, UIViewControllerRestoration
 		// Don't add the section when no value can be computed
 		let zero = NSDecimalNumber.zero()
 
-		if !(distance.compare(zero) == .OrderedDescending && fuelVolume.compare(zero) == .OrderedDescending) {
+		if distance <= zero || fuelVolume <= zero {
 			return
 		}
 
@@ -446,17 +446,17 @@ class FuelEventEditorController: PageViewController, UIViewControllerRestoration
 			}
 		} else if let newNumber = newValue as? NSDecimalNumber {
 			if valueIdentifier == "distance" {
-				if distance.compare(newNumber) != .OrderedSame {
+				if distance != newNumber {
 					distance = newNumber
 					dataChanged = true
 				}
 			} else if valueIdentifier == "price" {
-				if price.compare(newNumber) != .OrderedSame {
+				if price != newNumber {
 					price = newNumber
 					dataChanged = true
 				}
 			} else if valueIdentifier == "fuelVolume" {
-				if fuelVolume.compare(newNumber) != .OrderedSame {
+				if fuelVolume != newNumber {
 					fuelVolume = newNumber
 					dataChanged = true
 				}
@@ -475,7 +475,7 @@ class FuelEventEditorController: PageViewController, UIViewControllerRestoration
 
 		let zero = NSDecimalNumber.zero()
 
-		if !(distance.compare(zero) == .OrderedDescending && fuelVolume.compare(zero) == .OrderedDescending) {
+		if !(distance > zero && fuelVolume > zero) {
 			canBeSaved = false
 		} else if !date.isEqualToDate(event.timestamp) {
 			if AppDelegate.managedObjectContext(managedObjectContext, containsEventWithCar:car, andDate:date) {
@@ -501,7 +501,7 @@ class FuelEventEditorController: PageViewController, UIViewControllerRestoration
 		// DecimalNumbers <= 0.0 are invalid
 		if let decimalNumber = newValue as? NSDecimalNumber {
 			if valueIdentifier != "price" {
-				if decimalNumber.compare(NSDecimalNumber.zero()) != .OrderedDescending {
+				if decimalNumber <= NSDecimalNumber.zero() {
 					return false
 				}
 			}

--- a/Classes/FuelEventEditorController.swift
+++ b/Classes/FuelEventEditorController.swift
@@ -363,7 +363,7 @@ class FuelEventEditorController: PageViewController, UIViewControllerRestoration
               cellClass:NumberEditTableCell.self,
                cellData:["label": Units.fuelUnitDescription(fuelUnit, discernGallons:false, pluralization:true),
                          "suffix": " ".stringByAppendingString(Units.fuelUnitString(fuelUnit)),
-                         "formatter": KSVolumeIsMetric(fuelUnit) ? Formatters.sharedFuelVolumeFormatter : Formatters.sharedPreciseFuelVolumeFormatter,
+                         "formatter": fuelUnit.isMetric ? Formatters.sharedFuelVolumeFormatter : Formatters.sharedPreciseFuelVolumeFormatter,
                          "valueIdentifier": "fuelVolume"],
           withAnimation:animation)
 

--- a/Classes/FuelStatisticsGraphViewController.swift
+++ b/Classes/FuelStatisticsGraphViewController.swift
@@ -766,12 +766,12 @@ class FuelStatisticsViewControllerDataSourceAvgConsumption : FuelStatisticsViewC
 
 	@objc func graphRightBorder(rightBorder: CGFloat, forCar car: Car) -> CGFloat {
 		let consumptionUnit = car.ksFuelConsumptionUnit
-		return rightBorder - (KSFuelConsumptionIsGP10K (consumptionUnit) ? 16.0 : 0.0)
+		return rightBorder - (consumptionUnit.isGP10K ? 16.0 : 0.0)
 	}
 
 	@objc func graphWidth(graphWidth: CGFloat, forCar car: Car) -> CGFloat {
 		let consumptionUnit = car.ksFuelConsumptionUnit
-		return graphWidth - (KSFuelConsumptionIsGP10K (consumptionUnit) ? 16.0 : 0.0)
+		return graphWidth - (consumptionUnit.isGP10K ? 16.0 : 0.0)
 	}
 
 	@objc var curveGradient: CGGradientRef {
@@ -858,7 +858,7 @@ class FuelStatisticsViewControllerDataSourcePriceDistance : FuelStatisticsViewCo
 	@objc func averageFormatter(precise: Bool, forCar car: Car) -> NSNumberFormatter {
 		let distanceUnit = car.ksOdometerUnit
 
-		if KSDistanceIsMetric (distanceUnit) {
+		if distanceUnit.isMetric {
 			return Formatters.sharedCurrencyFormatter
 		} else {
 			return Formatters.sharedDistanceFormatter
@@ -868,7 +868,7 @@ class FuelStatisticsViewControllerDataSourcePriceDistance : FuelStatisticsViewCo
 	@objc func averageFormatString(avgPrefix: Bool, forCar car: Car) -> String {
 		let distanceUnit = car.ksOdometerUnit
 
-		if KSDistanceIsMetric(distanceUnit) {
+		if distanceUnit.isMetric {
 			return String(format:"%@%%@/100km", avgPrefix ? "∅ " : "")
 		} else {
 			return String(format:"%@%%@ mi/%@", avgPrefix ? "∅ " : "", Formatters.sharedCurrencyFormatter.currencySymbol!)
@@ -878,14 +878,14 @@ class FuelStatisticsViewControllerDataSourcePriceDistance : FuelStatisticsViewCo
 	@objc func noAverageStringForCar(car: Car) -> String {
 		let distanceUnit = car.ksOdometerUnit
 
-		return String(format:KSDistanceIsMetric(distanceUnit) ? "%@/100km" : "mi/%@",
+		return String(format:distanceUnit.isMetric ? "%@/100km" : "mi/%@",
 				Formatters.sharedCurrencyFormatter.currencySymbol!)
 	}
 
 	@objc func axisFormatterForCar(car: Car) -> NSNumberFormatter {
 		let distanceUnit = car.ksOdometerUnit
 
-		if KSDistanceIsMetric(distanceUnit) {
+		if distanceUnit.isMetric {
 			return Formatters.sharedAxisCurrencyFormatter
 		} else {
 			return Formatters.sharedDistanceFormatter
@@ -913,7 +913,7 @@ class FuelStatisticsViewControllerDataSourcePriceDistance : FuelStatisticsViewCo
 			return CGFloat.NaN
 		}
 
-		if KSDistanceIsMetric(distanceUnit) {
+		if distanceUnit.isMetric {
 			return CGFloat((cost << 2).decimalNumberByDividingBy(distance, withBehavior:handler).floatValue)
 		} else {
 			return CGFloat(distance.decimalNumberByDividingBy(Units.kilometersPerStatuteMile).decimalNumberByDividingBy(cost, withBehavior:handler).floatValue)

--- a/Classes/FuelStatisticsGraphViewController.swift
+++ b/Classes/FuelStatisticsGraphViewController.swift
@@ -358,7 +358,7 @@ class FuelStatisticsGraphViewController: FuelStatisticsViewController {
 			return
 		}
 
-		let font = UIFont(name:"HelveticaNeue-Light", size:12.0)!
+		let font = UIFont.lightApplicationFontForStyle(UIFontTextStyleFootnote)
 		let path = UIBezierPath()
 
 		if state.dataCount == 0	{
@@ -729,7 +729,7 @@ class FuelStatisticsGraphViewController: FuelStatisticsViewController {
 		path.fill()
 
 		// Layout for info box
-		let attributes = [ NSFontAttributeName:UIFont(name:"HelveticaNeue-Light", size:17)!,
+		let attributes = [ NSFontAttributeName:UIFont.lightApplicationFontForStyle(UIFontTextStyleCaption2),
                                  NSForegroundColorAttributeName:UIColor.whiteColor() ]
 
 		var infoRect = CGRect()

--- a/Classes/FuelStatisticsGraphViewController.swift
+++ b/Classes/FuelStatisticsGraphViewController.swift
@@ -842,7 +842,7 @@ class FuelStatisticsViewControllerDataSourcePriceAmount : FuelStatisticsViewCont
 	@objc func valueForFuelEvent(fuelEvent: FuelEvent, forCar car: Car) -> CGFloat {
 		let price = fuelEvent.price
 
-		if price.compare(NSDecimalNumber.zero()) == .OrderedSame {
+		if price == NSDecimalNumber.zero() {
 			return CGFloat.NaN
 		}
 
@@ -909,7 +909,7 @@ class FuelStatisticsViewControllerDataSourcePriceDistance : FuelStatisticsViewCo
 		distance = distance + fuelEvent.inheritedDistance
 		cost     = cost + fuelEvent.inheritedCost
 
-		if cost.compare(NSDecimalNumber.zero()) == .OrderedSame {
+		if cost == NSDecimalNumber.zero() {
 			return CGFloat.NaN
 		}
 

--- a/Classes/FuelStatisticsTextViewController.swift
+++ b/Classes/FuelStatisticsTextViewController.swift
@@ -368,7 +368,7 @@ class FuelStatisticsTextViewController: FuelStatisticsViewController {
 
             // cost per distance
 			let costPerDistanceLabel = String(format:NSLocalizedString("cost_per_x", comment:""), Units.odometerUnitDescription(odometerUnit, pluralization:false))
-			if zero.compare(state.totalDistance) == .OrderedAscending {
+			if zero < state.totalDistance {
 				let val = state.totalCost / Units.distanceForKilometers(state.totalDistance, withUnit:odometerUnit)
 				drawEntry(costPerDistanceLabel, String(format:"%@/%@", pcf.stringFromNumber(val)!, odometerUnitString))
 			} else {
@@ -377,7 +377,7 @@ class FuelStatisticsTextViewController: FuelStatisticsViewController {
 
             // cost per volume
 			let costPerVolumeLabel = String(format:NSLocalizedString("cost_per_x", comment:""), Units.fuelUnitDescription(fuelUnit, discernGallons:true, pluralization:false))
-			if zero.compare(state.totalFuelVolume) == .OrderedAscending {
+			if zero < state.totalFuelVolume {
 				let val = state.totalCost / Units.volumeForLiters(state.totalFuelVolume, withUnit:fuelUnit)
 				drawEntry(costPerVolumeLabel, String(format:"%@/%@", pcf.stringFromNumber(val)!, fuelUnitString))
 			} else {
@@ -422,7 +422,7 @@ class FuelStatisticsTextViewController: FuelStatisticsViewController {
 
             // distance per money
 			let distancePerMoneyLabel = String(format:NSLocalizedString("x_per_y", comment:""), Units.odometerUnitDescription(odometerUnit, pluralization:true), cf.currencySymbol!)
-			if zero.compare(state.totalCost) == .OrderedAscending {
+			if zero < state.totalCost {
 				let val = Units.distanceForKilometers(state.totalDistance, withUnit:odometerUnit) / state.totalCost
 				drawEntry(distancePerMoneyLabel, String(format: "%@ %@", nf.stringFromNumber(val)!, odometerUnitString))
 			} else {

--- a/Classes/FuelStatisticsTextViewController.swift
+++ b/Classes/FuelStatisticsTextViewController.swift
@@ -115,7 +115,7 @@ class FuelStatisticsTextViewController: FuelStatisticsViewController {
 
 				state.avgConsumption = state.avgConsumption + consumption
 
-				if KSFuelConsumptionIsEfficiency(consumptionUnit) {
+				if consumptionUnit.isEfficiency {
 					state.bestConsumption  = max(consumption, state.bestConsumption ?? consumption)
 					state.worstConsumption = min(consumption, state.worstConsumption ?? consumption)
 				} else {
@@ -326,17 +326,17 @@ class FuelStatisticsTextViewController: FuelStatisticsViewController {
 
             // avg consumption
             drawEntry(
-				NSLocalizedString(KSFuelConsumptionIsEfficiency(consumptionUnit) ? "avg_efficiency" : "avg_consumption", comment:""),
+				NSLocalizedString(consumptionUnit.isEfficiency ? "avg_efficiency" : "avg_consumption", comment:""),
                 String(format:"%@ %@", nf.stringFromNumber(state.avgConsumption)!, consumptionUnitString))
 
             // best consumption
 			drawEntry(
-				NSLocalizedString(KSFuelConsumptionIsEfficiency(consumptionUnit) ? "max_efficiency" : "min_consumption", comment:""),
+				NSLocalizedString(consumptionUnit.isEfficiency ? "max_efficiency" : "min_consumption", comment:""),
                 String(format:"%@ %@", nf.stringFromNumber(state.bestConsumption)!, consumptionUnitString))
 
             // worst consumption
 			drawEntry(
-				NSLocalizedString(KSFuelConsumptionIsEfficiency(consumptionUnit) ? "min_efficiency" : "max_consumption", comment:""),
+				NSLocalizedString(consumptionUnit.isEfficiency ? "min_efficiency" : "max_consumption", comment:""),
                 String(format:"%@ %@", nf.stringFromNumber(state.worstConsumption)!, consumptionUnitString))
 
             // total cost

--- a/Classes/NumberEditTableCell.swift
+++ b/Classes/NumberEditTableCell.swift
@@ -29,7 +29,7 @@ class NumberEditTableCell: EditablePageCell {
 		self.textField.textColor = valid ? UIColor.blackColor() : invalidTextColor
 	}
 
-	override func configureForData(object: AnyObject!, viewController: AnyObject!, tableView: UITableView!, indexPath: NSIndexPath) {
+	override func configureForData(object: AnyObject?, viewController: UIViewController, tableView: UITableView, indexPath: NSIndexPath) {
 		super.configureForData(object, viewController:viewController, tableView:tableView, indexPath:indexPath)
 
 		let dictionary = object as! [NSObject:AnyObject]

--- a/Classes/NumberEditTableCell.swift
+++ b/Classes/NumberEditTableCell.swift
@@ -81,11 +81,11 @@ class NumberEditTableCell: EditablePageCell {
 			}
 
 			// Don't append when the result gets too large or below zero
-			if value.compare(NSDecimalNumber(mantissa:1, exponent:6, isNegative:false)) != .OrderedAscending {
+			if value >= NSDecimalNumber(mantissa:1, exponent:6, isNegative:false) {
 				return false
 			}
 
-			if value.compare(NSDecimalNumber.zero()) == .OrderedAscending {
+			if value < NSDecimalNumber.zero() {
 				return false
 			}
 		} else if range.location >= count(text) - 1 {

--- a/Classes/PageCell.swift
+++ b/Classes/PageCell.swift
@@ -27,7 +27,7 @@ class PageCell: UITableViewCell {
 		// Suppress default behaviour
 	}
 
-	func configureForData(object: AnyObject!, viewController: AnyObject!, tableView: UITableView!, indexPath: NSIndexPath) {
+	func configureForData(object: AnyObject?, viewController: UIViewController, tableView: UITableView, indexPath: NSIndexPath) {
 		// Overridepoint for subclasses
 	}
 

--- a/Classes/PageViewController.swift
+++ b/Classes/PageViewController.swift
@@ -83,26 +83,25 @@ class PageViewController: UIViewController, UITableViewDelegate, UITableViewData
 	func dismissKeyboardWithCompletion(completion: () -> Void) {
 		let scrollToTop = (self.tableView.contentOffset.y > 0.0)
     
-		UIView.animateWithDuration(scrollToTop ? 0.25 : 0.15,
-                     animations: {
-                         
-						if let indexPath = self.tableView.indexPathForSelectedRow() {
-                             self.tableView.deselectRowAtIndexPath(indexPath, animated:false)
-						}
+		UIView.animateWithDuration(scrollToTop ? 0.25 : 0.15, animations: {
+			if let indexPath = self.tableView.indexPathForSelectedRow() {
+				self.tableView.deselectRowAtIndexPath(indexPath, animated:false)
+				self.tableView.delegate?.tableView?(self.tableView, didDeselectRowAtIndexPath: indexPath)
+			}
 
-						if scrollToTop {
-                             self.tableView.scrollToRowAtIndexPath(NSIndexPath(forRow:0, inSection:0),
-                                                   atScrollPosition:.Top,
-                                                           animated:false)
-						}
+			if scrollToTop {
+				self.tableView.scrollToRowAtIndexPath(NSIndexPath(forRow:0, inSection:0),
+					atScrollPosition:.Top,
+					animated:false)
+			}
 
-						var insets = self.tableView.contentInset
-						insets.bottom = self.bottomInsetBeforeKeyboard ?? 0.0
-						self.tableView.contentInset = insets
-                     }, completion: { finished in
-                         self.view.endEditing(true)
-                         completion()
-                     })
+			var insets = self.tableView.contentInset
+			insets.bottom = self.bottomInsetBeforeKeyboard ?? 0.0
+			self.tableView.contentInset = insets
+		}, completion: { finished in
+			self.view.endEditing(true)
+			completion()
+		})
 	}
 
 	//MARK: - Access to Table Cells

--- a/Classes/PickerTableCell.swift
+++ b/Classes/PickerTableCell.swift
@@ -13,20 +13,27 @@ class PickerTableCell: EditableProxyPageCell, UIPickerViewDataSource, UIPickerVi
 	var picker: UIPickerView
 	var pickerLabels: [String]!
 	var pickerShortLabels: [String]?
+	private var pickerConstraints = [NSLayoutConstraint]()
 
 	private let PickerViewCellWidth: CGFloat  = 290.0
 	private let PickerViewCellHeight: CGFloat =  44.0
 
 	required init() {
-		self.picker = UIPickerView()
+		picker = UIPickerView()
 
 		super.init()
 
-		self.picker.showsSelectionIndicator = true
-		self.picker.dataSource              = self
-		self.picker.delegate                = self
+		picker.showsSelectionIndicator = true
+		picker.dataSource              = self
+		picker.delegate                = self
+		picker.setTranslatesAutoresizingMaskIntoConstraints(false)
+		picker.hidden = true
+		let pickerHeightConstraint = NSLayoutConstraint(item: picker, attribute: .Height, relatedBy: .Equal, toItem: nil, attribute: .NotAnAttribute, multiplier: 1.0, constant: 162.0)
+		pickerHeightConstraint.priority = 750
+		picker.addConstraint(pickerHeightConstraint)
+		contentView.addSubview(picker)
 
-		self.textField.inputView = self.picker
+		pickerConstraints = NSLayoutConstraint.constraintsWithVisualFormat("V:[keyLabel]-[picker]-|", options: .allZeros, metrics: nil, views: ["keyLabel" : keyLabel, "picker" : picker]) as! [NSLayoutConstraint]
 	}
 
 	required init(coder aDecoder: NSCoder) {
@@ -55,6 +62,16 @@ class PickerTableCell: EditableProxyPageCell, UIPickerViewDataSource, UIPickerVi
 		self.textFieldProxy.text = (self.pickerShortLabels ?? self.pickerLabels)[row]
 
 		self.delegate.valueChanged(row, identifier:self.valueIdentifier)
+	}
+
+	private func showPicker(show: Bool) {
+		if show {
+			contentView.addConstraints(pickerConstraints)
+			picker.hidden = false
+		} else {
+			contentView.removeConstraints(pickerConstraints)
+			picker.hidden = true
+		}
 	}
 
 	//MARK: - UIPickerViewDataSource
@@ -95,5 +112,15 @@ class PickerTableCell: EditableProxyPageCell, UIPickerViewDataSource, UIPickerVi
 		label.text = self.pickerView(pickerView, titleForRow:row, forComponent:component)
 
 		return label
+	}
+
+	//MARK: - UITextFieldDelegate
+
+	func textFieldDidBeginEditing(textField: UITextField) {
+		showPicker(true)
+	}
+
+	override func textFieldDidEndEditing(textField: UITextField) {
+		showPicker(false)
 	}
 }

--- a/Classes/PickerTableCell.swift
+++ b/Classes/PickerTableCell.swift
@@ -88,7 +88,7 @@ class PickerTableCell: EditableProxyPageCell, UIPickerViewDataSource, UIPickerVi
 	func pickerView(pickerView: UIPickerView, viewForRow row: Int, forComponent component: Int, reusingView view: UIView!) -> UIView {
 		let label = (view as? UILabel) ?? UILabel()
 
-		label.font = UIFont.boldSystemFontOfSize(self.pickerShortLabels != nil ? 18 : 20)
+		label.font = UIFont.applicationFontForStyle(self.pickerShortLabels != nil ? UIFontTextStyleCaption2 : UIFontTextStyleCaption1)
 		label.frame = CGRect(x:0.0, y:0.0, width:PickerViewCellWidth-20.0, height:PickerViewCellHeight)
 		label.backgroundColor = UIColor.clearColor()
 

--- a/Classes/PickerTableCell.swift
+++ b/Classes/PickerTableCell.swift
@@ -33,7 +33,7 @@ class PickerTableCell: EditableProxyPageCell, UIPickerViewDataSource, UIPickerVi
 	    fatalError("init(coder:) has not been implemented")
 	}
 
-	override func configureForData(object: AnyObject!, viewController: AnyObject!, tableView: UITableView!, indexPath: NSIndexPath) {
+	override func configureForData(object: AnyObject?, viewController: UIViewController, tableView: UITableView, indexPath: NSIndexPath) {
 		super.configureForData(object, viewController:viewController, tableView:tableView, indexPath:indexPath)
 
 		let dictionary = object as! [NSObject:AnyObject]

--- a/Classes/SwitchTableCell.swift
+++ b/Classes/SwitchTableCell.swift
@@ -81,7 +81,7 @@ class SwitchTableCell: PageCell {
 	    fatalError("init(coder:) has not been implemented")
 	}
 
-	override func configureForData(object: AnyObject!, viewController: AnyObject!, tableView: UITableView!, indexPath: NSIndexPath) {
+	override func configureForData(object: AnyObject?, viewController: UIViewController, tableView: UITableView, indexPath: NSIndexPath) {
 		super.configureForData(object, viewController:viewController, tableView:tableView, indexPath:indexPath)
 
 		let dictionary = object as! [String:AnyObject]

--- a/Classes/TextEditTableCell.swift
+++ b/Classes/TextEditTableCell.swift
@@ -24,7 +24,7 @@ class TextEditTableCell: EditablePageCell {
 	    fatalError("init(coder:) has not been implemented")
 	}
 
-	override func configureForData(object: AnyObject!, viewController: AnyObject!, tableView: UITableView!, indexPath: NSIndexPath) {
+	override func configureForData(object: AnyObject?, viewController: UIViewController, tableView: UITableView, indexPath: NSIndexPath) {
 		super.configureForData(object, viewController:viewController, tableView:tableView, indexPath:indexPath)
 
 		let dictionary = object as! [NSObject:AnyObject]

--- a/Classes/Units.swift
+++ b/Classes/Units.swift
@@ -13,6 +13,10 @@ public enum KSDistance: Int32 {
 	case Invalid = -1
 	case Kilometer
 	case StatuteMile
+
+	var isMetric: Bool {
+		return self == .Kilometer
+	}
 }
 
 public enum KSVolume: Int32 {
@@ -20,6 +24,10 @@ public enum KSVolume: Int32 {
 	case Liter
 	case GalUS
 	case GalUK
+
+	var isMetric: Bool {
+		return self == .Liter
+	}
 }
 
 public enum KSFuelConsumption: Int32 {
@@ -30,15 +38,19 @@ public enum KSFuelConsumption: Int32 {
 	case MilesPerGallonUK
 	case GP10KUS
 	case GP10KUK
+
+	var isMetric: Bool {
+		return self == .LitersPer100km || self == .KilometersPerLiter
+	}
+
+	var isEfficiency: Bool {
+		return self == .KilometersPerLiter || self == .MilesPerGallonUS || self == .MilesPerGallonUK
+	}
+
+	var isGP10K: Bool {
+		return self == .GP10KUS || self == .GP10KUS
+	}
 }
-
-func KSDistanceIsMetric(x: KSDistance) -> Bool { return x == .Kilometer }
-
-func KSVolumeIsMetric(x: KSVolume) -> Bool { return x == .Liter }
-
-func KSFuelConsumptionIsMetric(x: KSFuelConsumption) -> Bool     { return x == .LitersPer100km || x == .KilometersPerLiter }
-func KSFuelConsumptionIsEfficiency(x: KSFuelConsumption) -> Bool { return x == .KilometersPerLiter || x == .MilesPerGallonUS || x == .MilesPerGallonUK }
-func KSFuelConsumptionIsGP10K(x: KSFuelConsumption) -> Bool      { return x == .GP10KUS || x == .GP10KUS }
 
 final class Units {
 
@@ -147,7 +159,7 @@ final class Units {
 			return NSDecimalNumber.notANumber()
 		}
 
-		if KSFuelConsumptionIsEfficiency(unit) {
+		if unit.isEfficiency {
 			let kmPerLiter = kilometers / liters
 
 			switch unit {
@@ -254,7 +266,7 @@ final class Units {
 	}
 
 	static func fuelPriceUnitDescription(unit: KSVolume) -> String {
-		if KSVolumeIsMetric(unit) {
+		if unit.isMetric {
 			return NSLocalizedString("Price per Liter", comment:"")
 		} else {
 			return NSLocalizedString("Price per Gallon", comment:"")
@@ -262,7 +274,7 @@ final class Units {
 	}
 
 	static func odometerUnitString(unit: KSDistance) -> String {
-		if KSDistanceIsMetric(unit) {
+		if unit.isMetric {
 			return "km"
 		} else {
 			return "mi"
@@ -271,9 +283,9 @@ final class Units {
 
 	static func odometerUnitDescription(unit: KSDistance, pluralization plural: Bool) -> String {
 		if plural {
-			return KSDistanceIsMetric(unit) ? NSLocalizedString("Kilometers", comment:"") : NSLocalizedString("Miles", comment:"")
+			return unit.isMetric ? NSLocalizedString("Kilometers", comment:"") : NSLocalizedString("Miles", comment:"")
 		} else {
-			return KSDistanceIsMetric(unit) ? NSLocalizedString("Kilometer", comment:"")  : NSLocalizedString("Mile", comment:"")
+			return unit.isMetric ? NSLocalizedString("Kilometer", comment:"")  : NSLocalizedString("Mile", comment:"")
 		}
 	}
 

--- a/Kraftstoff.xcodeproj/project.xcworkspace/xcshareddata/kraftstoff.xccheckout
+++ b/Kraftstoff.xcodeproj/project.xcworkspace/xcshareddata/kraftstoff.xccheckout
@@ -7,14 +7,14 @@
 	<key>IDESourceControlProjectIdentifier</key>
 	<string>42C25C78-757A-4F76-8A4F-22BB3EFB41A4</string>
 	<key>IDESourceControlProjectName</key>
-	<string>Kraftstoff</string>
+	<string>project</string>
 	<key>IDESourceControlProjectOriginsDictionary</key>
 	<dict>
 		<key>5062D133DCCD8E607F8BAF86CF2EAAD52EBAD063</key>
 		<string>https://github.com/IngmarStein/Kraftstoff.git</string>
 	</dict>
 	<key>IDESourceControlProjectPath</key>
-	<string>Kraftstoff.xcodeproj</string>
+	<string>Kraftstoff.xcodeproj/project.xcworkspace</string>
 	<key>IDESourceControlProjectRelativeInstallPathDictionary</key>
 	<dict>
 		<key>5062D133DCCD8E607F8BAF86CF2EAAD52EBAD063</key>

--- a/Kraftstoff.xcodeproj/project.xcworkspace/xcshareddata/kraftstoff.xccheckout
+++ b/Kraftstoff.xcodeproj/project.xcworkspace/xcshareddata/kraftstoff.xccheckout
@@ -7,14 +7,14 @@
 	<key>IDESourceControlProjectIdentifier</key>
 	<string>42C25C78-757A-4F76-8A4F-22BB3EFB41A4</string>
 	<key>IDESourceControlProjectName</key>
-	<string>project</string>
+	<string>Kraftstoff</string>
 	<key>IDESourceControlProjectOriginsDictionary</key>
 	<dict>
 		<key>5062D133DCCD8E607F8BAF86CF2EAAD52EBAD063</key>
 		<string>https://github.com/IngmarStein/Kraftstoff.git</string>
 	</dict>
 	<key>IDESourceControlProjectPath</key>
-	<string>Kraftstoff.xcodeproj/project.xcworkspace</string>
+	<string>Kraftstoff.xcodeproj</string>
 	<key>IDESourceControlProjectRelativeInstallPathDictionary</key>
 	<dict>
 		<key>5062D133DCCD8E607F8BAF86CF2EAAD52EBAD063</key>

--- a/kraftstoff-Info.plist
+++ b/kraftstoff-Info.plist
@@ -36,7 +36,7 @@
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>1943</string>
+	<string>1946</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>UILaunchStoryboardName</key>

--- a/kraftstoff-Info.plist
+++ b/kraftstoff-Info.plist
@@ -36,7 +36,7 @@
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>1940</string>
+	<string>1943</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>UILaunchStoryboardName</key>

--- a/kraftstoff-Info.plist
+++ b/kraftstoff-Info.plist
@@ -36,7 +36,7 @@
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>1956</string>
+	<string>1990</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>UILaunchStoryboardName</key>

--- a/kraftstoff-Info.plist
+++ b/kraftstoff-Info.plist
@@ -36,7 +36,7 @@
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>1946</string>
+	<string>1953</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>UILaunchStoryboardName</key>

--- a/kraftstoff-Info.plist
+++ b/kraftstoff-Info.plist
@@ -36,7 +36,7 @@
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>1953</string>
+	<string>1954</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>UILaunchStoryboardName</key>

--- a/kraftstoff-Info.plist
+++ b/kraftstoff-Info.plist
@@ -36,7 +36,7 @@
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>1954</string>
+	<string>1956</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>UILaunchStoryboardName</key>


### PR DESCRIPTION
The [HIG](https://developer.apple.com/library/ios/documentation/UserExperience/Conceptual/MobileHIG/Controls.html) and the [iOS 7 transition guide](https://developer.apple.com/library/ios/documentation/UserExperience/Conceptual/TransitionGuide/Controls.html#//apple_ref/doc/uid/TP40013174-CH9-SW3) state "As much as possible, display a date picker inline with the content." and "iOS 7 apps tend to embed date pickers within the content instead of displaying them in a different view. For example, Calendar dynamically expands a table row to let users specify a time without leaving the event-creation view". Therefore, move the picker views inside the tables instead of using them as inputViews for UITextFields.
